### PR TITLE
Extract OS X and iOS frameworks to allow modularity

### DIFF
--- a/Mac/NWAppDelegate.m
+++ b/Mac/NWAppDelegate.m
@@ -6,12 +6,7 @@
 //
 
 #import "NWAppDelegate.h"
-#import "NWHub.h"
-#import "NWNotification.h"
-#import "NWSecTools.h"
-#import "NWLCore.h"
-#import "NWPushFeedback.h"
-
+#import <PusherKit/PusherKit.h>
 
 @interface NWAppDelegate () <NWHubDelegate> @end
 

--- a/NWPusher.xcodeproj/project.pbxproj
+++ b/NWPusher.xcodeproj/project.pbxproj
@@ -7,9 +7,45 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5C7803881D3C4668002107FB /* PusherKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7803861D3C4668002107FB /* PusherKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78038B1D3C4668002107FB /* PusherKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C7803841D3C4668002107FB /* PusherKit.framework */; };
+		5C78038C1D3C4668002107FB /* PusherKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C7803841D3C4668002107FB /* PusherKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C7803911D3C4683002107FB /* NWHub.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A1189682D30043DA98 /* NWHub.m */; };
+		5C7803921D3C4683002107FB /* NWNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A3189682D30043DA98 /* NWNotification.m */; };
+		5C7803931D3C4683002107FB /* NWPusher.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A5189682D30043DA98 /* NWPusher.m */; };
+		5C7803941D3C4683002107FB /* NWPushFeedback.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A7189682D30043DA98 /* NWPushFeedback.m */; };
+		5C7803951D3C4683002107FB /* NWSecTools.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A9189682D30043DA98 /* NWSecTools.m */; };
+		5C7803961D3C4683002107FB /* NWSSLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232AB189682D30043DA98 /* NWSSLConnection.m */; };
+		5C7803971D3C4683002107FB /* NWType.m in Sources */ = {isa = PBXBuildFile; fileRef = B34BF1B318DDF401004BA9F7 /* NWType.m */; };
+		5C7803981D3C4698002107FB /* NWLCore.c in Sources */ = {isa = PBXBuildFile; fileRef = B3376A61172BB71200242EBB /* NWLCore.c */; };
+		5C7803991D3C4749002107FB /* NWHub.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A0189682D30043DA98 /* NWHub.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78039A1D3C4749002107FB /* NWNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A2189682D30043DA98 /* NWNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78039B1D3C4749002107FB /* NWPusher.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A4189682D30043DA98 /* NWPusher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78039C1D3C4749002107FB /* NWPushFeedback.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A6189682D30043DA98 /* NWPushFeedback.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78039D1D3C4749002107FB /* NWSecTools.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A8189682D30043DA98 /* NWSecTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78039E1D3C4749002107FB /* NWSSLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232AA189682D30043DA98 /* NWSSLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C78039F1D3C4749002107FB /* NWType.h in Headers */ = {isa = PBXBuildFile; fileRef = B34BF1B218DDF401004BA9F7 /* NWType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803A01D3C4749002107FB /* NWLCore.h in Headers */ = {isa = PBXBuildFile; fileRef = B3376A62172BB71200242EBB /* NWLCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803AA1D3C4826002107FB /* PusherKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7803A81D3C4826002107FB /* PusherKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803AD1D3C4826002107FB /* PusherKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C7803A61D3C4826002107FB /* PusherKit.framework */; };
+		5C7803AF1D3C4826002107FB /* PusherKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C7803A61D3C4826002107FB /* PusherKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5C7803B31D3C486F002107FB /* NWLCore.c in Sources */ = {isa = PBXBuildFile; fileRef = B3376A61172BB71200242EBB /* NWLCore.c */; };
+		5C7803B41D3C487B002107FB /* NWHub.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A1189682D30043DA98 /* NWHub.m */; };
+		5C7803B51D3C487B002107FB /* NWNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A3189682D30043DA98 /* NWNotification.m */; };
+		5C7803B61D3C487B002107FB /* NWPusher.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A5189682D30043DA98 /* NWPusher.m */; };
+		5C7803B71D3C487B002107FB /* NWPushFeedback.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A7189682D30043DA98 /* NWPushFeedback.m */; };
+		5C7803B81D3C487B002107FB /* NWSecTools.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A9189682D30043DA98 /* NWSecTools.m */; };
+		5C7803B91D3C487B002107FB /* NWSSLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232AB189682D30043DA98 /* NWSSLConnection.m */; };
+		5C7803BA1D3C487B002107FB /* NWType.m in Sources */ = {isa = PBXBuildFile; fileRef = B34BF1B318DDF401004BA9F7 /* NWType.m */; };
+		5C7803BB1D3C488C002107FB /* NWHub.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A0189682D30043DA98 /* NWHub.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803BC1D3C488C002107FB /* NWNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A2189682D30043DA98 /* NWNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803BD1D3C488C002107FB /* NWPusher.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A4189682D30043DA98 /* NWPusher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803BE1D3C488C002107FB /* NWPushFeedback.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A6189682D30043DA98 /* NWPushFeedback.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803BF1D3C488C002107FB /* NWSecTools.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232A8189682D30043DA98 /* NWSecTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803C01D3C488C002107FB /* NWSSLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = B3F232AA189682D30043DA98 /* NWSSLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803C11D3C488C002107FB /* NWType.h in Headers */ = {isa = PBXBuildFile; fileRef = B34BF1B218DDF401004BA9F7 /* NWType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5C7803C21D3C488C002107FB /* NWLCore.h in Headers */ = {isa = PBXBuildFile; fileRef = B3376A62172BB71200242EBB /* NWLCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3005FC318F43659009BB7C3 /* Application.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3005FC218F43659009BB7C3 /* Application.xib */; };
-		B3376A63172BB71200242EBB /* NWLCore.c in Sources */ = {isa = PBXBuildFile; fileRef = B3376A61172BB71200242EBB /* NWLCore.c */; };
-		B3376A64172BB71200242EBB /* NWLCore.c in Sources */ = {isa = PBXBuildFile; fileRef = B3376A61172BB71200242EBB /* NWLCore.c */; };
 		B33FB1C8172B185C006529CE /* icon.icns in Resources */ = {isa = PBXBuildFile; fileRef = B33FB1BB172B185C006529CE /* icon.icns */; };
 		B33FB1C9172B185C006529CE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B33FB1BC172B185C006529CE /* main.m */; };
 		B33FB1CB172B185C006529CE /* NWAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B33FB1BF172B185C006529CE /* NWAppDelegate.m */; };
@@ -26,8 +62,6 @@
 		B33FB215172B303D006529CE /* Icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B33FB211172B303D006529CE /* Icon-72@2x.png */; };
 		B33FB216172B303D006529CE /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = B33FB212172B303D006529CE /* icon.png */; };
 		B33FB217172B303D006529CE /* Icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B33FB213172B303D006529CE /* Icon@2x.png */; };
-		B34BF1B418DDF401004BA9F7 /* NWType.m in Sources */ = {isa = PBXBuildFile; fileRef = B34BF1B318DDF401004BA9F7 /* NWType.m */; };
-		B34BF1B518DDF401004BA9F7 /* NWType.m in Sources */ = {isa = PBXBuildFile; fileRef = B34BF1B318DDF401004BA9F7 /* NWType.m */; };
 		B395BA12172BC17A00631932 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B3C6BE0015FD30E900F1F3F1 /* README.md */; };
 		B3AFABEF172C81910027346A /* config.plist in Resources */ = {isa = PBXBuildFile; fileRef = B3AFABEE172C81910027346A /* config.plist */; };
 		B3B4DCD318A7998300F9F258 /* LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = B3B4DCD218A7998300F9F258 /* LICENSE.txt */; };
@@ -36,21 +70,57 @@
 		B3C6BDD315FD27E900F1F3F1 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3C6BDD215FD27E900F1F3F1 /* Security.framework */; };
 		B3C6BE0115FD30E900F1F3F1 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B3C6BE0015FD30E900F1F3F1 /* README.md */; };
 		B3F23256189657DA0043DA98 /* pusher.p12 in Resources */ = {isa = PBXBuildFile; fileRef = B3F23255189657DA0043DA98 /* pusher.p12 */; };
-		B3F232AE189682D30043DA98 /* NWHub.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A1189682D30043DA98 /* NWHub.m */; };
-		B3F232AF189682D30043DA98 /* NWHub.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A1189682D30043DA98 /* NWHub.m */; };
-		B3F232B0189682D30043DA98 /* NWNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A3189682D30043DA98 /* NWNotification.m */; };
-		B3F232B1189682D30043DA98 /* NWNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A3189682D30043DA98 /* NWNotification.m */; };
-		B3F232B2189682D30043DA98 /* NWPusher.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A5189682D30043DA98 /* NWPusher.m */; };
-		B3F232B3189682D30043DA98 /* NWPusher.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A5189682D30043DA98 /* NWPusher.m */; };
-		B3F232B4189682D30043DA98 /* NWPushFeedback.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A7189682D30043DA98 /* NWPushFeedback.m */; };
-		B3F232B5189682D30043DA98 /* NWPushFeedback.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A7189682D30043DA98 /* NWPushFeedback.m */; };
-		B3F232B6189682D30043DA98 /* NWSecTools.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A9189682D30043DA98 /* NWSecTools.m */; };
-		B3F232B7189682D30043DA98 /* NWSecTools.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232A9189682D30043DA98 /* NWSecTools.m */; };
-		B3F232B8189682D30043DA98 /* NWSSLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232AB189682D30043DA98 /* NWSSLConnection.m */; };
-		B3F232B9189682D30043DA98 /* NWSSLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F232AB189682D30043DA98 /* NWSSLConnection.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		5C7803891D3C4668002107FB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B3C6BD7215FD24D200F1F3F1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C7803831D3C4668002107FB;
+			remoteInfo = "PusherKit-iOS";
+		};
+		5C7803AB1D3C4826002107FB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B3C6BD7215FD24D200F1F3F1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C7803A51D3C4826002107FB;
+			remoteInfo = "PusherKit-OSX";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		5C7803901D3C4668002107FB /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				5C78038C1D3C4668002107FB /* PusherKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5C7803AE1D3C4826002107FB /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				5C7803AF1D3C4826002107FB /* PusherKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		5C7803841D3C4668002107FB /* PusherKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PusherKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C7803861D3C4668002107FB /* PusherKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PusherKit.h; sourceTree = "<group>"; };
+		5C7803871D3C4668002107FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5C7803A61D3C4826002107FB /* PusherKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PusherKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C7803A81D3C4826002107FB /* PusherKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PusherKit.h; sourceTree = "<group>"; };
+		5C7803A91D3C4826002107FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B3005FC218F43659009BB7C3 /* Application.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = Application.xib; sourceTree = "<group>"; };
 		B3376A61172BB71200242EBB /* NWLCore.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = NWLCore.c; path = Mac/NWLCore.c; sourceTree = SOURCE_ROOT; };
 		B3376A62172BB71200242EBB /* NWLCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NWLCore.h; path = Mac/NWLCore.h; sourceTree = SOURCE_ROOT; };
@@ -106,11 +176,26 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5C7803801D3C4668002107FB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5C7803A21D3C4826002107FB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B33FB1CE172B1A66006529CE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				B33FB20F172B1EC2006529CE /* Security.framework in Frameworks */,
+				5C78038B1D3C4668002107FB /* PusherKit.framework in Frameworks */,
 				B33FB204172B1BAD006529CE /* CoreGraphics.framework in Frameworks */,
 				B33FB202172B1BA5006529CE /* Foundation.framework in Frameworks */,
 				B33FB200172B1B9F006529CE /* UIKit.framework in Frameworks */,
@@ -123,12 +208,31 @@
 			files = (
 				B3C6BDD315FD27E900F1F3F1 /* Security.framework in Frameworks */,
 				B3C6BD8015FD24D200F1F3F1 /* Cocoa.framework in Frameworks */,
+				5C7803AD1D3C4826002107FB /* PusherKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5C7803851D3C4668002107FB /* PusherKit-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				5C7803861D3C4668002107FB /* PusherKit.h */,
+				5C7803871D3C4668002107FB /* Info.plist */,
+			);
+			path = "PusherKit-iOS";
+			sourceTree = "<group>";
+		};
+		5C7803A71D3C4826002107FB /* PusherKit-OSX */ = {
+			isa = PBXGroup;
+			children = (
+				5C7803A81D3C4826002107FB /* PusherKit.h */,
+				5C7803A91D3C4826002107FB /* Info.plist */,
+			);
+			path = "PusherKit-OSX";
+			sourceTree = "<group>";
+		};
 		B3376A5F172B9EFD00242EBB /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -193,6 +297,8 @@
 				B3F2329D189682D30043DA98 /* Classes */,
 				B33FB1BA172B185C006529CE /* Mac */,
 				B33FB1ED172B1A7A006529CE /* Touch */,
+				5C7803851D3C4668002107FB /* PusherKit-iOS */,
+				5C7803A71D3C4826002107FB /* PusherKit-OSX */,
 				B3C6BD7E15FD24D200F1F3F1 /* Frameworks */,
 				B3C6BD7C15FD24D200F1F3F1 /* Products */,
 			);
@@ -203,6 +309,8 @@
 			children = (
 				B3C6BD7B15FD24D200F1F3F1 /* Pusher.app */,
 				B33FB1D1172B1A66006529CE /* PusherTouch.app */,
+				5C7803841D3C4668002107FB /* PusherKit.framework */,
+				5C7803A61D3C4826002107FB /* PusherKit.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -245,7 +353,78 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		5C7803811D3C4668002107FB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C7803881D3C4668002107FB /* PusherKit.h in Headers */,
+				5C7803991D3C4749002107FB /* NWHub.h in Headers */,
+				5C78039A1D3C4749002107FB /* NWNotification.h in Headers */,
+				5C78039B1D3C4749002107FB /* NWPusher.h in Headers */,
+				5C78039C1D3C4749002107FB /* NWPushFeedback.h in Headers */,
+				5C78039D1D3C4749002107FB /* NWSecTools.h in Headers */,
+				5C78039E1D3C4749002107FB /* NWSSLConnection.h in Headers */,
+				5C78039F1D3C4749002107FB /* NWType.h in Headers */,
+				5C7803A01D3C4749002107FB /* NWLCore.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5C7803A31D3C4826002107FB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C7803AA1D3C4826002107FB /* PusherKit.h in Headers */,
+				5C7803BB1D3C488C002107FB /* NWHub.h in Headers */,
+				5C7803BC1D3C488C002107FB /* NWNotification.h in Headers */,
+				5C7803BD1D3C488C002107FB /* NWPusher.h in Headers */,
+				5C7803BE1D3C488C002107FB /* NWPushFeedback.h in Headers */,
+				5C7803BF1D3C488C002107FB /* NWSecTools.h in Headers */,
+				5C7803C01D3C488C002107FB /* NWSSLConnection.h in Headers */,
+				5C7803C11D3C488C002107FB /* NWType.h in Headers */,
+				5C7803C21D3C488C002107FB /* NWLCore.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		5C7803831D3C4668002107FB /* PusherKit-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5C78038F1D3C4668002107FB /* Build configuration list for PBXNativeTarget "PusherKit-iOS" */;
+			buildPhases = (
+				5C78037F1D3C4668002107FB /* Sources */,
+				5C7803801D3C4668002107FB /* Frameworks */,
+				5C7803811D3C4668002107FB /* Headers */,
+				5C7803821D3C4668002107FB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PusherKit-iOS";
+			productName = "PusherKit-iOS";
+			productReference = 5C7803841D3C4668002107FB /* PusherKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5C7803A51D3C4826002107FB /* PusherKit-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5C7803B01D3C4826002107FB /* Build configuration list for PBXNativeTarget "PusherKit-OSX" */;
+			buildPhases = (
+				5C7803A11D3C4826002107FB /* Sources */,
+				5C7803A21D3C4826002107FB /* Frameworks */,
+				5C7803A31D3C4826002107FB /* Headers */,
+				5C7803A41D3C4826002107FB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PusherKit-OSX";
+			productName = "PusherKit-OSX";
+			productReference = 5C7803A61D3C4826002107FB /* PusherKit.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		B33FB1D0172B1A66006529CE /* PusherTouch */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B33FB1EA172B1A66006529CE /* Build configuration list for PBXNativeTarget "PusherTouch" */;
@@ -253,10 +432,12 @@
 				B33FB1CD172B1A66006529CE /* Sources */,
 				B33FB1CE172B1A66006529CE /* Frameworks */,
 				B33FB1CF172B1A66006529CE /* Resources */,
+				5C7803901D3C4668002107FB /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				5C78038A1D3C4668002107FB /* PBXTargetDependency */,
 			);
 			name = PusherTouch;
 			productName = PusherTouch;
@@ -270,10 +451,12 @@
 				B3C6BD7715FD24D200F1F3F1 /* Sources */,
 				B3C6BD7815FD24D200F1F3F1 /* Frameworks */,
 				B3C6BD7915FD24D200F1F3F1 /* Resources */,
+				5C7803AE1D3C4826002107FB /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				5C7803AC1D3C4826002107FB /* PBXTargetDependency */,
 			);
 			name = PusherMac;
 			productName = Pusher;
@@ -289,6 +472,16 @@
 				CLASSPREFIX = NW;
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = noodlewerk;
+				TargetAttributes = {
+					5C7803831D3C4668002107FB = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					5C7803A51D3C4826002107FB = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = B3C6BD7515FD24D200F1F3F1 /* Build configuration list for PBXProject "NWPusher" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -304,11 +497,27 @@
 			targets = (
 				B3C6BD7A15FD24D200F1F3F1 /* PusherMac */,
 				B33FB1D0172B1A66006529CE /* PusherTouch */,
+				5C7803831D3C4668002107FB /* PusherKit-iOS */,
+				5C7803A51D3C4826002107FB /* PusherKit-OSX */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5C7803821D3C4668002107FB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5C7803A41D3C4826002107FB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B33FB1CF172B1A66006529CE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -341,20 +550,42 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5C78037F1D3C4668002107FB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C7803951D3C4683002107FB /* NWSecTools.m in Sources */,
+				5C7803961D3C4683002107FB /* NWSSLConnection.m in Sources */,
+				5C7803911D3C4683002107FB /* NWHub.m in Sources */,
+				5C7803941D3C4683002107FB /* NWPushFeedback.m in Sources */,
+				5C7803981D3C4698002107FB /* NWLCore.c in Sources */,
+				5C7803921D3C4683002107FB /* NWNotification.m in Sources */,
+				5C7803971D3C4683002107FB /* NWType.m in Sources */,
+				5C7803931D3C4683002107FB /* NWPusher.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5C7803A11D3C4826002107FB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C7803B81D3C487B002107FB /* NWSecTools.m in Sources */,
+				5C7803B41D3C487B002107FB /* NWHub.m in Sources */,
+				5C7803BA1D3C487B002107FB /* NWType.m in Sources */,
+				5C7803B71D3C487B002107FB /* NWPushFeedback.m in Sources */,
+				5C7803B61D3C487B002107FB /* NWPusher.m in Sources */,
+				5C7803B51D3C487B002107FB /* NWNotification.m in Sources */,
+				5C7803B31D3C486F002107FB /* NWLCore.c in Sources */,
+				5C7803B91D3C487B002107FB /* NWSSLConnection.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B33FB1CD172B1A66006529CE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				B33FB1FC172B1A7A006529CE /* main.m in Sources */,
-				B3F232B5189682D30043DA98 /* NWPushFeedback.m in Sources */,
 				B33FB1FD172B1A7A006529CE /* NWAppDelegate.m in Sources */,
-				B34BF1B518DDF401004BA9F7 /* NWType.m in Sources */,
-				B3F232AF189682D30043DA98 /* NWHub.m in Sources */,
-				B3F232B7189682D30043DA98 /* NWSecTools.m in Sources */,
-				B3F232B3189682D30043DA98 /* NWPusher.m in Sources */,
-				B3F232B9189682D30043DA98 /* NWSSLConnection.m in Sources */,
-				B3F232B1189682D30043DA98 /* NWNotification.m in Sources */,
-				B3376A64172BB71200242EBB /* NWLCore.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -362,22 +593,207 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3F232B4189682D30043DA98 /* NWPushFeedback.m in Sources */,
-				B3F232AE189682D30043DA98 /* NWHub.m in Sources */,
-				B3F232B6189682D30043DA98 /* NWSecTools.m in Sources */,
-				B34BF1B418DDF401004BA9F7 /* NWType.m in Sources */,
-				B3F232B2189682D30043DA98 /* NWPusher.m in Sources */,
-				B3F232B8189682D30043DA98 /* NWSSLConnection.m in Sources */,
-				B3F232B0189682D30043DA98 /* NWNotification.m in Sources */,
 				B33FB1C9172B185C006529CE /* main.m in Sources */,
 				B33FB1CB172B185C006529CE /* NWAppDelegate.m in Sources */,
-				B3376A63172BB71200242EBB /* NWLCore.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		5C78038A1D3C4668002107FB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C7803831D3C4668002107FB /* PusherKit-iOS */;
+			targetProxy = 5C7803891D3C4668002107FB /* PBXContainerItemProxy */;
+		};
+		5C7803AC1D3C4826002107FB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C7803A51D3C4826002107FB /* PusherKit-OSX */;
+			targetProxy = 5C7803AB1D3C4826002107FB /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		5C78038D1D3C4668002107FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "PusherKit-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zats.PusherKit-iOS";
+				PRODUCT_NAME = PusherKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5C78038E1D3C4668002107FB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "PusherKit-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zats.PusherKit-iOS";
+				PRODUCT_NAME = PusherKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		5C7803B11D3C4826002107FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "PusherKit-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zats.PusherKit-OSX";
+				PRODUCT_NAME = PusherKit;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5C7803B21D3C4826002107FB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "PusherKit-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.zats.PusherKit-OSX";
+				PRODUCT_NAME = PusherKit;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		B33FB1EB172B1A66006529CE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -398,7 +814,8 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Touch/PusherTouch-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.noodlewerk.pusher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -424,7 +841,8 @@
 				GCC_PREFIX_HEADER = "Touch/PusherTouch-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "NWL_LIB=Pusher";
 				INFOPLIST_FILE = "Touch/PusherTouch-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_BUNDLE_IDENTIFIER = com.noodlewerk.pusher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -486,6 +904,7 @@
 		B3C6BD9A15FD24D200F1F3F1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Mac/PusherMac-Prefix.pch";
@@ -494,6 +913,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Mac/PusherMac-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.noodlewerk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pusher;
@@ -504,6 +924,7 @@
 		B3C6BD9B15FD24D200F1F3F1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Mac/PusherMac-Prefix.pch";
@@ -512,6 +933,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Mac/PusherMac-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.noodlewerk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pusher;
@@ -522,6 +944,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5C78038F1D3C4668002107FB /* Build configuration list for PBXNativeTarget "PusherKit-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5C78038D1D3C4668002107FB /* Debug */,
+				5C78038E1D3C4668002107FB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		5C7803B01D3C4826002107FB /* Build configuration list for PBXNativeTarget "PusherKit-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5C7803B11D3C4826002107FB /* Debug */,
+				5C7803B21D3C4826002107FB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		B33FB1EA172B1A66006529CE /* Build configuration list for PBXNativeTarget "PusherTouch" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/NWPusher.xcodeproj/xcshareddata/xcschemes/PusherKit-OSX.xcscheme
+++ b/NWPusher.xcodeproj/xcshareddata/xcschemes/PusherKit-OSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5C7803A51D3C4826002107FB"
+               BuildableName = "PusherKit-OSX.framework"
+               BlueprintName = "PusherKit-OSX"
+               ReferencedContainer = "container:NWPusher.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C7803A51D3C4826002107FB"
+            BuildableName = "PusherKit-OSX.framework"
+            BlueprintName = "PusherKit-OSX"
+            ReferencedContainer = "container:NWPusher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C7803A51D3C4826002107FB"
+            BuildableName = "PusherKit-OSX.framework"
+            BlueprintName = "PusherKit-OSX"
+            ReferencedContainer = "container:NWPusher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/NWPusher.xcodeproj/xcshareddata/xcschemes/PusherKit-iOS.xcscheme
+++ b/NWPusher.xcodeproj/xcshareddata/xcschemes/PusherKit-iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5C7803831D3C4668002107FB"
+               BuildableName = "PusherKit.framework"
+               BlueprintName = "PusherKit-iOS"
+               ReferencedContainer = "container:NWPusher.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C7803831D3C4668002107FB"
+            BuildableName = "PusherKit.framework"
+            BlueprintName = "PusherKit-iOS"
+            ReferencedContainer = "container:NWPusher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C7803831D3C4668002107FB"
+            BuildableName = "PusherKit.framework"
+            BlueprintName = "PusherKit-iOS"
+            ReferencedContainer = "container:NWPusher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PusherKit-OSX/Info.plist
+++ b/PusherKit-OSX/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 noodlewerk. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/PusherKit-OSX/PusherKit.h
+++ b/PusherKit-OSX/PusherKit.h
@@ -1,0 +1,24 @@
+//
+//  PusherKit-OSX.h
+//  PusherKit-OSX
+//
+//  Created by Sash Zats on 7/17/16.
+//  Copyright © 2016 noodlewerk. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+//! Project version number for PusherKit-OSX.
+FOUNDATION_EXPORT double PusherKit_OSXVersionNumber;
+
+//! Project version string for PusherKit-OSX.
+FOUNDATION_EXPORT const unsigned char PusherKit_OSXVersionString[];
+
+#import <PusherKit/NWHub.h>
+#import <PusherKit/NWLCore.h>
+#import <PusherKit/NWNotification.h>
+#import <PusherKit/NWPushFeedback.h>
+#import <PusherKit/NWPusher.h>
+#import <PusherKit/NWSSLConnection.h>
+#import <PusherKit/NWSecTools.h>
+

--- a/PusherKit-iOS/Info.plist
+++ b/PusherKit-iOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/PusherKit-iOS/PusherKit.h
+++ b/PusherKit-iOS/PusherKit.h
@@ -1,0 +1,22 @@
+//
+//  PusherKit-iOS.h
+//  PusherKit-iOS
+//
+//  Created by Sash Zats on 7/17/16.
+//  Copyright © 2016 noodlewerk. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for PusherKit-iOS.
+FOUNDATION_EXPORT double PusherKit_iOSVersionNumber;
+
+//! Project version string for PusherKit-iOS.
+FOUNDATION_EXPORT const unsigned char PusherKit_iOSVersionString[];
+
+#import <PusherKit/NWHub.h>
+#import <PusherKit/NWLCore.h>
+#import <PusherKit/NWNotification.h>
+#import <PusherKit/NWPusher.h>
+#import <PusherKit/NWSSLConnection.h>
+#import <PusherKit/NWSecTools.h>

--- a/Touch/NWAppDelegate.m
+++ b/Touch/NWAppDelegate.m
@@ -6,12 +6,7 @@
 //
 
 #import "NWAppDelegate.h"
-#import "NWHub.h"
-#import "NWPusher.h"
-#import "NWNotification.h"
-#import "NWLCore.h"
-#import "NWSSLConnection.h"
-#import "NWSecTools.h"
+#import <PusherKit/PusherKit.h>
 
 // TODO: Export your push certificate and key in PKCS12 format to pusher.p12 in the root of the project directory.
 static NSString * const pkcs12FileName = @"pusher.p12";


### PR DESCRIPTION
Hi, I wanted to leverage your great code in one of my projects without pulling the dependancies manually.
For that I extracted relevant aspects into OS X and iOS frameworks allowing to use project through Carthage dependency manager. It doesn't affect existent projects in any way, except for bumping minimum required version for iOS app to 8.0, which is the minimum version allowing embedded frameworks.