### PR TITLE
Update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 Install the Mac app using [Homebrew cask](https://github.com/caskroom/homebrew-cask):
 
 ```shell
-brew cask install pusher
+brew install pusher
 ```
 
 Or download the latest `Pusher.app` binary:


### PR DESCRIPTION
You no longer use the cask parameter when installing a brew cask. It will result in an error. I updated the main README to reflect this.